### PR TITLE
Fix bug where skip configuration is not used

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,7 @@
 
 ### Unreleased
 
+- Fix bug where skip configuration was ignored
 
 ### [1.2.0] - 2023-01-19
 

--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ exports.helo_spf = async function (next, connection, helo) {
   const plugin = this;
 
   // bypass auth'ed or relay'ing hosts if told to
-  const skip_reason = exports.skip_hosts(connection);
+  const skip_reason = this.skip_hosts(connection);
   if (skip_reason) {
     connection.results.add(plugin, {skip: `helo(${skip_reason})`});
     return next();
@@ -147,7 +147,7 @@ exports.hook_mail = async function (next, connection, params) {
   if (!txn) return next();
 
   // bypass auth'ed or relay'ing hosts if told to
-  const skip_reason = exports.skip_hosts(connection);
+  const skip_reason = this.skip_hosts(connection);
   if (skip_reason) {
     txn.results.add(plugin, {skip: `host(${skip_reason})`});
     return next(CONT, `skipped because host(${skip_reason})`);


### PR DESCRIPTION
Call skip_hosts via plugin and not exports to make sure 'this' is set correctly.

This also makes the existing "txn, relaying, is_private" test pass

Checklist:
- [ ] docs updated
- [ ] tests updated
- [X] Changes.md updated
