### PR TITLE
Misc fixes

### DIFF
--- a/bin/spf
+++ b/bin/spf
@@ -34,8 +34,12 @@ if (parsed.domain) {
   }
 }
 
-spf.check_host(parsed.ip, (domain ? domain : parsed.helo), null, function (err, result) {
-  if (err) {
+(async () => {
+  let result;
+  try {
+    result = await spf.check_host(parsed.ip, (domain ? domain : parsed.helo));
+  }
+  catch (err) {
     console.log(`Error: ${err.message}`);
     process.exit(1);
   }
@@ -45,4 +49,4 @@ spf.check_host(parsed.ip, (domain ? domain : parsed.helo), null, function (err, 
     `domain="${(domain ? domain : '')}"`,
     `result=${spf.result(result)}`
   ].join(' '));
-})
+})();

--- a/bin/spf
+++ b/bin/spf
@@ -34,19 +34,14 @@ if (parsed.domain) {
   }
 }
 
-(async () => {
-  let result;
-  try {
-    result = await spf.check_host(parsed.ip, (domain ? domain : parsed.helo));
-  }
-  catch (err) {
-    console.log(`Error: ${err.message}`);
-    process.exit(1);
-  }
+spf.check_host(parsed.ip, (domain ? domain : parsed.helo)).then((result) => {
   console.log([
     `ip=${parsed.ip}`,
     `helo="${(parsed.helo ? parsed.helo : '')}"`,
     `domain="${(domain ? domain : '')}"`,
     `result=${spf.result(result)}`
   ].join(' '));
-})();
+}).catch((err) => {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+});

--- a/lib/spf.js
+++ b/lib/spf.js
@@ -193,7 +193,11 @@ class SPF {
 
     let spf_record;
     let match;
-    for (const txt_rr of txt_rrs) {
+    for (let txt_rr of txt_rrs) {
+      // txt_rr might be an array, so handle that case
+      if (Array.isArray(txt_rr)) {
+        txt_rr = txt_rr.join('');
+      }
 
       match = /^(v=spf1(?:$|\s.+$))/i.exec(txt_rr);
       if (!match) {

--- a/lib/spf.js
+++ b/lib/spf.js
@@ -657,6 +657,10 @@ class SPF {
     // NOT IMPLEMENTED
     return this.SPF_NONE
   }
+
+  async mod_v (str) {
+    return this.SPF_NONE
+  }
 }
 
 exports.SPF = SPF;

--- a/test/spf.js
+++ b/test/spf.js
@@ -78,6 +78,13 @@ describe('SPF', function () {
     }
   })
 
+  it('check_host, facebook.com, pass', async function () {
+    this.timeout = 3000;
+    this.SPF.count = 0;
+    const rc = await this.SPF.check_host('69.171.232.145', 'facebookmail.com');
+    assert.equal(rc, this.SPF.SPF_PASS, "pass");
+  })
+
   it('valid_ip, true', function (done) {
     assert.equal(this.SPF.valid_ip(':212.70.129.94'), true);
     done()


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixes bug when array is returned on longer SPF records, for example:

````
found SPF record for domain facebookmail.com: v=spf1 ip4:66.220.144.128/25 ip4:66.220.155.0/24 ip4:66.220.157.0/25 ip4:69.63.178.128/25 ip4:69.63.181.0/24 ip4:69.63.184.0/25, ip4:69.171.232.0/24 ip4:69.171.244.0/23 -all
syntax error: ip4:69.63.184.0/25,
````
- `spf` command-line tool was still using callbacks, so the result was not being returned correctly
- silence `skipping unknown modifier: v` error by adding modifier function

Checklist:
- [ ] docs updated
- [x] tests updated
- [ ] Changes.md updated
