### PR TITLE
fix: avoid exception on undefined mx

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,9 @@
 
 ### Unreleased
 
+### [1.2.4] - 2023-09-07
+
+- fix: avoid exception on undefined mx
 
 ### [1.2.3] - 2023-07-14
 

--- a/lib/spf.js
+++ b/lib/spf.js
@@ -503,7 +503,7 @@ class SPF {
 
       pending--;
       if (addrs) {
-        this.log_debug(`mech_mx: mx=${mx} addresses=${addrs.join(',')}`);
+        this.log_debug(`mech_mx: mx=${mx} addresses=${addrs?.join(',')}`);
         addresses = addrs.concat(addresses);
       }
       if (pending === 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-spf",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Sender Policy Framework (SPF) plugin for Haraka",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes the CRIT error below when the mx can't be resolved:

```
[CRIT] [-] [core] TypeError: Cannot read properties of undefined (reading 'join')
[CRIT] [-] [core]     at SPF.mech_mx (/mypath/Haraka/node_modules/haraka-plugin-spf/lib/spf.js:504:59)
[CRIT] [-] [core]     at async SPF.check_host (/mypath/Haraka/node_modules/haraka-plugin-spf/lib/spf.js:290:22)
```

Observed with node 16, haraka 3.0.2.

Checklist:
- [ ] docs updated
- [ ] tests updated
- [x] Changes.md updated
