### PR TITLE
fix(mech_MX): fix crit error on logging undef addrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### [1.2.8] - 2024-10-07
 
-- fix: mech_MX fix crit error on logging undef addrs
+- fix: mech_MX crit error on logging undef addrs
 
 ### [1.2.7] - 2024-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+### [1.2.8] - 2024-10-07
+
+- fix: mech_MX fix crit error on logging undef addrs
+
 ### [1.2.7] - 2024-08-14
 
 - test: in index.js, unref timers, so test suite exits

--- a/lib/spf.js
+++ b/lib/spf.js
@@ -520,8 +520,8 @@ class SPF {
         }
       }
 
-      this.log_debug(`mech_mx: mx=${mx} addresses=${addrs.join(',')}`)
-      addresses = addrs.concat(addresses)
+      this.log_debug(`mech_mx: mx=${mx} addresses=${addrs?.join(',')}`)
+      addresses = addrs ? addrs.concat(addresses) : [];
     }
 
     if (!addresses.length) return this.SPF_NONE

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-spf",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Sender Policy Framework (SPF) plugin for Haraka",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Fixes this error:

```
[CRIT] [-] [core] TypeError: Cannot read properties of undefined (reading 'join')
[CRIT] [-] [core]     at SPF.mech_mx (/<path>/Haraka/node_modules/haraka-plugin-spf/lib/spf.js:523:59)
[CRIT] [-] [core]     at async SPF.check_host (/<path>/Haraka/node_modules/haraka-plugin-spf/lib/spf.js:307:22)
```

Checklist:

- [ ] docs updated
- [ ] tests updated
- [x] Changes.md updated
