### PR TITLE
Release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+### [1.3.0] - 2026-05-19
+
+- changed: replaced address-rfc2821 with @haraka/email-address
 - fix: global dot-escape + (?:^|\.) boundary anchor
 - fix: mech_include catch now returns SPF_TEMPERROR and logs error
 - fix: pre-check changed to >= LIMIT (blocks the 11th)
@@ -12,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - feat: per-DNS-query timeout (configurable via `dns_timeout`)
 - feat: %{p} macro expands via fcrdns plugin's validated PTR (RFC 7208 §7.3)
 - doc: list `exp=` as unsupported in README
+- feat(spf): injectable DNS resolver so tests exercise the real resolver path
+  - replaces flaky public-DNS lookups (gmail/aexp/facebook/google)
+- changed: bump deps to latest
 - changed: remove unnecessary done callbacks in tests (#38)
 - changed: test runner is now node:test
 - feat(spf): injectable DNS resolver so tests exercise the real resolver path
@@ -137,3 +143,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 [1.2.9]: https://github.com/haraka/haraka-plugin-spf/releases/tag/v1.2.9
 [1.2.10]: https://github.com/haraka/haraka-plugin-spf/releases/tag/v1.2.10
 [1.2.11]: https://github.com/haraka/haraka-plugin-spf/releases/tag/v1.2.11
+[1.3.0]: https://github.com/haraka/haraka-plugin-spf/releases/tag/v1.3.0

--- a/index.js
+++ b/index.js
@@ -154,7 +154,7 @@ exports.hook_mail = async function (next, connection, params) {
     }
   }
 
-  const mfrom = params[0].address()
+  const mfrom = params[0].address
   const host = params[0].host
   let spf = this._configure_spf(new SPF(), connection)
   let auth_result

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-spf",
-  "version": "1.2.11",
+  "version": "1.3.0",
   "description": "Sender Policy Framework (SPF) plugin for Haraka",
   "main": "index.js",
   "files": [
@@ -47,7 +47,7 @@
     "nopt": "^10.0.0"
   },
   "devDependencies": {
-    "address-rfc2821": "^2.2.0",
+    "@haraka/email-address": "^3.1.4",
     "@haraka/eslint-config": "^2.0.4",
     "haraka-test-fixtures": "^1.6.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,7 @@ const assert = require('node:assert')
 const { describe, it, beforeEach } = require('node:test')
 
 // npm modules
-const Address = require('address-rfc2821').Address
+const { Address } = require('@haraka/email-address')
 const constants = require('haraka-constants')
 const fixtures = require('haraka-test-fixtures')
 


### PR DESCRIPTION
- changed: replaced address-rfc2821 with @haraka/email-address
  - related to https://github.com/haraka/Haraka/issues/3564
- fix: global dot-escape + (?:^|\.) boundary anchor
- fix: mech_include catch now returns SPF_TEMPERROR and logs error
- fix: pre-check changed to >= LIMIT (blocks the 11th)
- fix: README links stale RFC 4408 → RFC 7208
- fix: enforce RFC 7208 §4.6.4 void-lookup limit (PermError after 2)
- feat: per-DNS-query timeout (configurable via `dns_timeout`)
- feat: %{p} macro expands via fcrdns plugin's validated PTR (RFC 7208 §7.3)
- doc: list `exp=` as unsupported in README
- feat(spf): injectable DNS resolver so tests exercise the real resolver path
  - replaces flaky public-DNS lookups (gmail/aexp/facebook/google)
- changed: bump deps to latest
- changed: remove unnecessary done callbacks in tests (#38)
- changed: test runner is now node:test
