### PR TITLE
Audit/fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+- fix: global dot-escape + (?:^|\.) boundary anchor
+- fix: mech_include catch now returns SPF_TEMPERROR and logs error
+- fix: pre-check changed to >= LIMIT (blocks the 11th)
+- fix: README links stale RFC 4408 → RFC 7208
+- fix: enforce RFC 7208 §4.6.4 void-lookup limit (PermError after 2)
+- feat: per-DNS-query timeout (configurable via `dns_timeout`)
+- feat: %{p} macro expands via fcrdns plugin's validated PTR (RFC 7208 §7.3)
+- doc: list `exp=` as unsupported in README
 - changed: remove unnecessary done callbacks in tests (#38)
 - changed: test runner is now node:test
 - feat(spf): injectable DNS resolver so tests exercise the real resolver path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### [1.2.11] - 2026-02-13
 
+- feat(DSN): update with modern DSN values
 - style(header): fold the SPF header, remove redundant server name
 - test: update SPF test to no longer fail, #36
 - dep(nopt): bump to v9

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ By default this plugin only adds Received-SPF headers to a message. There are op
 ; The lookup timeout, in seconds. Setting it lower is better.
 lookup_timeout = 29
 
+; Per-DNS-query timeout, in seconds. Bounds each individual DNS lookup so a
+; single slow or unresponsive resolver can't burn the whole lookup_timeout
+; budget. Defaults to lookup_timeout - 1.
+;dns_timeout = 28
+
 
 [relay]
 context=sender
@@ -118,7 +123,22 @@ openspf_text = true
   email lists which frequently break SPF. SPF results are best used as inputs
   to other plugins such as DMARC, [spamassassin](https://haraka.github.io/plugins/spamassassin), and [karma](http://haraka.github.io/plugins/karma).
 
-- Heed well the implications of SPF, as described in [RFC 4408](http://tools.ietf.org/html/rfc4408#section-9.3)
+- Heed well the implications of SPF, as described in [RFC 7208 §11](https://www.rfc-editor.org/rfc/rfc7208#section-11)
+
+### Unsupported RFC 7208 features
+
+The following parts of RFC 7208 are not implemented. None of these affect
+the SPF result (`Pass`/`Fail`/etc.); they only affect ancillary behaviour.
+
+- The `exp=` modifier (§6.2) is parsed and accepted but its explanation
+  string is never fetched or expanded. Senders that publish `exp=` will
+  not have their custom explanation reflected in rejection responses.
+
+The `%{p}` macro (§7.3) expands to the connecting IP's validated PTR
+name when the [fcrdns](https://github.com/haraka/haraka-plugin-fcrdns)
+plugin is loaded before this one and has produced a forward-confirmed
+result; otherwise it falls back to `unknown`. RFC 7208 §7.3 says "do
+not use" — implementation is for completeness only.
 
 ## Testing
 

--- a/config/spf.ini
+++ b/config/spf.ini
@@ -1,6 +1,7 @@
 ; See 'haraka -h spf' for options
 [main]
 ; lookup_timeout = 29
+; dns_timeout = 8
 
 [relay]
 ; context=sender

--- a/index.js
+++ b/index.js
@@ -268,14 +268,13 @@ exports.return_results = function (
   const deny = connection.relaying ? 'deny_relay' : 'deny'
   const defer = connection.relaying ? 'defer_relay' : 'defer'
   const sender_id = scope === 'helo' ? connection.hello_host : sender
-  let text = DSN.sec_unauthorized(
-    `http://www.openspf.org/Why?s=${scope}&id=${sender_id}&ip=${connection.remote.ip}`,
-  )
+  const openspf_url = `http://www.openspf.org/Why?s=${scope}&id=${sender_id}&ip=${connection.remote.ip}`
+  let text
   switch (result) {
     case spf.SPF_NONE:
       if (this.cfg[deny][`${scope}_none`]) {
         text = this.cfg[deny].openspf_text
-          ? text
+          ? DSN.sec_unauthorized(openspf_url)
           : `${msgpre} SPF record not found`
         return next(DENY, text)
       }
@@ -285,24 +284,28 @@ exports.return_results = function (
       return next()
     case spf.SPF_SOFTFAIL:
       if (this.cfg[deny][`${scope}_softfail`]) {
-        text = this.cfg[deny].openspf_text ? text : `${msgpre} SPF SoftFail`
+        text = this.cfg[deny].openspf_text
+          ? DSN.sec_spf_fail(openspf_url)
+          : `${msgpre} SPF SoftFail`
         return next(DENY, text)
       }
       return next()
     case spf.SPF_FAIL:
       if (this.cfg[deny][`${scope}_fail`]) {
-        text = this.cfg[deny].openspf_text ? text : `${msgpre} SPF Fail`
+        text = this.cfg[deny].openspf_text
+          ? DSN.sec_spf_fail(openspf_url)
+          : `${msgpre} SPF Fail`
         return next(DENY, text)
       }
       return next()
     case spf.SPF_TEMPERROR:
       if (this.cfg[defer][`${scope}_temperror`]) {
-        return next(DENYSOFT, `${msgpre} SPF Temporary Error`)
+        return next(DENYSOFT, DSN.sec_spf_error(`${msgpre} SPF Temporary Error`))
       }
       return next()
     case spf.SPF_PERMERROR:
       if (this.cfg[deny][`${scope}_permerror`]) {
-        return next(DENY, `${msgpre} SPF Permanent Error`)
+        return next(DENY, DSN.sec_spf_fail(`${msgpre} SPF Permanent Error`))
       }
       return next()
     default:

--- a/index.js
+++ b/index.js
@@ -59,6 +59,20 @@ exports.load_spf_ini = function () {
 
   if (!this.cfg.relay) this.cfg.relay = { context: 'sender' }
   this.cfg.lookup_timeout = this.cfg.main.lookup_timeout || this.timeout - 1
+  // Per-DNS-query timeout (seconds). Smaller than lookup_timeout lets a
+  // single slow/black-holed query fail without burning the whole hook.
+  this.cfg.dns_timeout =
+    this.cfg.main.dns_timeout || Math.max(1, this.cfg.lookup_timeout - 1)
+}
+
+exports._configure_spf = function (spf, connection) {
+  spf.dns_timeout_ms = this.cfg.dns_timeout * 1000
+  // RFC 7208 §7.3: %{p} macro expands to a validated PTR name. Reuse
+  // the fcrdns plugin's forward-confirmed list if available; fall
+  // back to "unknown" otherwise.
+  const fcrdns = connection?.results?.get?.('fcrdns')
+  if (fcrdns?.fcrdns?.length) spf.p_name = fcrdns.fcrdns[0]
+  return spf
 }
 
 exports.helo_spf = async function (next, connection, helo) {
@@ -74,8 +88,8 @@ exports.helo_spf = async function (next, connection, helo) {
     return next()
   }
 
-  // RFC 4408, 2.1: "SPF clients must be prepared for the "HELO"
-  //           identity to be malformed or an IP address literal.
+  // RFC 7208 §2.3: SPF clients must be prepared for the HELO
+  // identity to be malformed or an IP address literal.
   if (net_utils.is_ip_literal(helo)) {
     connection.results.add(this, { skip: 'helo(ip_literal)' })
     return next()
@@ -86,7 +100,7 @@ exports.helo_spf = async function (next, connection, helo) {
   if (results && results.domain === helo) return next()
 
   let timeout = false
-  const spf = new SPF()
+  const spf = this._configure_spf(new SPF(), connection)
   const timer = setTimeout(() => {
     timeout = true
     connection.loginfo(this, 'timeout')
@@ -142,7 +156,7 @@ exports.hook_mail = async function (next, connection, params) {
 
   const mfrom = params[0].address()
   const host = params[0].host
-  let spf = new SPF()
+  let spf = this._configure_spf(new SPF(), connection)
   let auth_result
 
   if (connection.notes?.spf_helo) {
@@ -238,7 +252,7 @@ exports.hook_mail = async function (next, connection, params) {
     const spf_result = result ? spf.result(result).toLowerCase() : undefined
     if (spf_result && spf_result !== 'pass') {
       if (!my_public_ip) return ch_cb(new Error('failed to discover public IP'))
-      spf = new SPF()
+      spf = this._configure_spf(new SPF(), connection)
       const r = await spf.check_host(my_public_ip, host, mfrom)
       return ch_cb(null, r, my_public_ip)
     }
@@ -300,7 +314,10 @@ exports.return_results = function (
       return next()
     case spf.SPF_TEMPERROR:
       if (this.cfg[defer][`${scope}_temperror`]) {
-        return next(DENYSOFT, DSN.sec_spf_error(`${msgpre} SPF Temporary Error`))
+        return next(
+          DENYSOFT,
+          DSN.sec_spf_error(`${msgpre} SPF Temporary Error`),
+        )
       }
       return next()
     case spf.SPF_PERMERROR:

--- a/lib/spf.js
+++ b/lib/spf.js
@@ -7,7 +7,7 @@ const ipaddr = require('ipaddr.js')
 const net_utils = require('haraka-net-utils')
 
 class SPF {
-  constructor(count, been_there) {
+  constructor(count, been_there, void_count) {
     // For macro expansion
     // This should be set before check_host() is called
     this.helo = 'unknown'
@@ -16,7 +16,7 @@ class SPF {
     // Store any matching include record for analysis
     this.spf_record_include_match = {}
 
-    // RFC 4408 Section 10.1
+    // RFC 7208 §4.6.4
     // Limit the number of mechanisms/modifiers that require DNS lookups to complete.
     this.count = 0
 
@@ -27,8 +27,21 @@ class SPF {
     this.been_there = {}
     if (been_there) this.been_there = been_there
 
-    // RFC 4408 Section 10.1
+    // RFC 7208 §4.6.4: a "void lookup" is a DNS query returning rcode 0
+    // with no answers or rcode 3 (NXDOMAIN). The default ceiling is two;
+    // a third void produces PermError.
+    this.void_count = 0
+    if (void_count) this.void_count = void_count
+
+    // RFC 7208 §4.6.4
     this.LIMIT = 10
+    this.VOID_LIMIT = 2
+
+    // Per-call DNS timeout in ms. The outer plugin hook timer bounds
+    // the whole evaluation; this bounds each individual DNS query so a
+    // single slow/black-holed resolver can't burn the entire hook
+    // budget on one mechanism. Set to 0 to disable.
+    this.dns_timeout_ms = 30000
 
     // Constants
     this.SPF_NONE = 1
@@ -128,16 +141,17 @@ class SPF {
         case 'i': // IP
           replace = this.ip
           break
-        case 'p': // validated domain name of IP
-          // NOT IMPLEMENTED
-          replace = 'unknown'
+        case 'p': // validated domain name of IP (RFC 7208 §7.3)
+          // Set by the plugin from the fcrdns plugin's validated-PTR
+          // list. RFC §7.3 says "do not use" — kept for completeness.
+          replace = this.p_name || 'unknown'
           break
         case 'v': // IP version
           try {
             if (this.ip_ver === 'ipv4') kind = 'in-addr'
             if (this.ip_ver === 'ipv6') kind = 'ip6'
             replace = kind
-          } catch (e) {}
+          } catch {}
           break
         case 'h': // EHLO/HELO domain
           replace = this.helo
@@ -163,6 +177,35 @@ class SPF {
 
   log_debug(str) {
     console.error(str)
+  }
+
+  // RFC 7208 §4.6.4 void lookup: rcode 0 with no answers or rcode 3.
+  // node:dns surfaces both as ENODATA/ENOTFOUND-family error codes.
+  _is_void_err(err) {
+    return (
+      err &&
+      (err.code === dns.NOTFOUND ||
+        err.code === dns.NODATA ||
+        err.code === dns.NXDOMAIN)
+    )
+  }
+
+  // Bound an individual DNS-producing promise. On timeout, reject with
+  // a code that the existing catch blocks route to TempError.
+  _withTimeout(promise, label) {
+    if (!this.dns_timeout_ms) return promise
+    let timer
+    const timeout = new Promise((_, reject) => {
+      timer = setTimeout(() => {
+        const e = new Error(
+          `SPF DNS timeout (${label}) after ${this.dns_timeout_ms}ms`,
+        )
+        e.code = 'ETIMEOUT'
+        reject(e)
+      }, this.dns_timeout_ms)
+      timer.unref?.()
+    })
+    return Promise.race([promise, timeout]).finally(() => clearTimeout(timer))
   }
 
   valid_ip(ip) {
@@ -199,17 +242,17 @@ class SPF {
     // Get the SPF record for domain
     let txt_rrs
     try {
-      txt_rrs = await this.resolver.resolveTxt(domain)
+      txt_rrs = await this._withTimeout(
+        this.resolver.resolveTxt(domain),
+        `resolveTxt ${domain}`,
+      )
     } catch (err) {
       this.log_debug(`error looking up TXT record: ${err.message}`)
-      switch (err.code) {
-        case dns.NOTFOUND:
-        case dns.NODATA:
-        case dns.NXDOMAIN:
-          return this.SPF_NONE
-        default:
-          return this.SPF_TEMPERROR
+      if (this._is_void_err(err)) {
+        this.void_count++
+        return this.SPF_NONE
       }
+      return this.SPF_TEMPERROR
     }
 
     let spf_record
@@ -302,12 +345,12 @@ class SPF {
     for (const mech of mech_array) {
       const func = Object.keys(mech)
       const args = mech[func]
-      // console.log(`running mechanism: ${func} args=${args} domain=${this.domain}`);
       this.log_debug(
         `running mechanism: ${func} args=${args} domain=${this.domain}`,
       )
 
-      if (this.count > this.LIMIT) {
+      // RFC 7208 §4.6.4: at most 10 DNS-producing terms.
+      if (this.count >= this.LIMIT) {
         this.log_debug('lookup limit reached')
         return this.SPF_PERMERROR
       }
@@ -316,7 +359,17 @@ class SPF {
         args && args.length ? args[0] : null,
         args && args.length ? args[1] : null,
       )
-      // console.log(result)
+
+      // Re-check after the mechanism ran: it may have bumped this.count
+      // past the limit internally, and we must not honor its verdict.
+      if (this.count > this.LIMIT) {
+        this.log_debug('lookup limit reached')
+        return this.SPF_PERMERROR
+      }
+      if (this.void_count > this.VOID_LIMIT) {
+        this.log_debug('void-lookup limit reached')
+        return this.SPF_PERMERROR
+      }
 
       // If we have a result other than SPF_NONE
       if (result && result !== this.SPF_NONE) return result
@@ -329,11 +382,20 @@ class SPF {
       this.log_debug(
         `running modifier: ${func} args=${args} domain=${this.domain}`,
       )
+
+      if (this.count >= this.LIMIT) {
+        this.log_debug('lookup limit reached')
+        return this.SPF_PERMERROR
+      }
+
       const result = await this[`mod_${func}`](args)
 
-      // Check limits
       if (this.count > this.LIMIT) {
         this.log_debug('lookup limit reached')
+        return this.SPF_PERMERROR
+      }
+      if (this.void_count > this.VOID_LIMIT) {
+        this.log_debug('void-lookup limit reached')
         return this.SPF_PERMERROR
       }
 
@@ -357,11 +419,14 @@ class SPF {
     }
     this.count++
     this.been_there[domain] = true
-    // Recurse
-    const recurse = new SPF(this.count, this.been_there)
+    // Recurse, sharing count/void_count budgets per RFC 7208 §4.6.4.
+    const recurse = new SPF(this.count, this.been_there, this.void_count)
     recurse.resolver = this.resolver
+    recurse.dns_timeout_ms = this.dns_timeout_ms
     try {
       const result = await recurse.check_host(this.ip, domain, this.mail_from)
+      this.count = recurse.count
+      this.void_count = recurse.void_count
       this.log_debug(
         `mech_include: domain=${domain} returned=${this.const_translate(result)}`,
       )
@@ -384,7 +449,8 @@ class SPF {
           return this.SPF_PERMERROR
       }
     } catch (err) {
-      // ignore
+      this.log_debug(`mech_include: ${domain} error: ${err.message}`)
+      return this.SPF_TEMPERROR
     }
   }
 
@@ -393,19 +459,19 @@ class SPF {
     const exists = args.substr(1)
 
     try {
-      const addrs = await this.resolver.resolve(exists)
+      const addrs = await this._withTimeout(
+        this.resolver.resolve(exists),
+        `resolve ${exists}`,
+      )
       this.log_debug(`mech_exists: ${exists} result=${addrs.join(',')}`)
       return this.return_const(qualifier)
     } catch (err) {
       this.log_debug(`mech_exists: ${err}`)
-      switch (err.code) {
-        case dns.NOTFOUND:
-        case dns.NODATA:
-        case dns.NXDOMAIN:
-          return this.SPF_NONE
-        default:
-          return this.SPF_TEMPERROR
+      if (this._is_void_err(err)) {
+        this.void_count++
+        return this.SPF_NONE
       }
+      return this.SPF_TEMPERROR
     }
   }
 
@@ -437,17 +503,17 @@ class SPF {
     // Use current domain
     let addrs
     try {
-      addrs = await this.resolver[resolve_method](domain)
+      addrs = await this._withTimeout(
+        this.resolver[resolve_method](domain),
+        `${resolve_method} ${domain}`,
+      )
     } catch (err) {
       this.log_debug(`mech_a: ${err}`)
-      switch (err.code) {
-        case dns.NOTFOUND:
-        case dns.NODATA:
-        case dns.NXDOMAIN:
-          return this.SPF_NONE
-        default:
-          return this.SPF_TEMPERROR
+      if (this._is_void_err(err)) {
+        this.void_count++
+        return this.SPF_NONE
       }
+      return this.SPF_TEMPERROR
     }
 
     if (!addrs) return this.SPF_NONE
@@ -491,21 +557,21 @@ class SPF {
     // Fetch the MX records for the specified domain
     let mxes
     try {
-      mxes = await net_utils.get_mx(domain)
+      mxes = await this._withTimeout(
+        net_utils.get_mx(domain),
+        `get_mx ${domain}`,
+      )
       mxes = mxes.filter((mx) => !net.isIP(mx.exchange)) // remove implicit MX
     } catch (err) {
-      switch (err.code) {
-        case dns.NOTFOUND:
-        case dns.NODATA:
-        case dns.NXDOMAIN:
-          return this.SPF_NONE
-        default:
-          return this.SPF_TEMPERROR
+      if (this._is_void_err(err)) {
+        this.void_count++
+        return this.SPF_NONE
       }
+      return this.SPF_TEMPERROR
     }
 
     let addresses = []
-    // RFC 4408 Section 10.1
+    // RFC 7208 §4.6.4
     if (mxes.length > this.LIMIT) return this.SPF_PERMERROR
 
     let cidr
@@ -523,16 +589,12 @@ class SPF {
 
       let addrs = []
       try {
-        addrs = await this.resolver[resolve_method](mx)
+        addrs = await this._withTimeout(
+          this.resolver[resolve_method](mx),
+          `${resolve_method} ${mx}`,
+        )
       } catch (err) {
-        switch (err.code) {
-          case dns.NOTFOUND:
-          case dns.NODATA:
-          case dns.NXDOMAIN:
-            break
-          default:
-            return this.SPF_TEMPERROR
-        }
+        if (!this._is_void_err(err)) return this.SPF_TEMPERROR
       }
 
       this.log_debug(`mech_mx: mx=${mx} addresses=${addrs?.join(',')}`)
@@ -579,9 +641,13 @@ class SPF {
     // First do a PTR lookup for the connecting IP
     let ptrs
     try {
-      ptrs = await this.resolver.reverse(this.ip)
+      ptrs = await this._withTimeout(
+        this.resolver.reverse(this.ip),
+        `reverse ${this.ip}`,
+      )
     } catch (err) {
       this.log_debug(`mech_ptr: lookup=${this.ip} => ${err}`)
+      if (this._is_void_err(err)) this.void_count++
       return this.SPF_NONE
     }
 
@@ -589,12 +655,15 @@ class SPF {
     if (this.ip_ver === 'ipv4') resolve_method = 'resolve4'
     if (this.ip_ver === 'ipv6') resolve_method = 'resolve6'
     const names = []
-    // RFC 4408 Section 10.1
+    // RFC 7208 §4.6.4
     if (ptrs.length > this.LIMIT) return this.SPF_PERMERROR
 
     for (const ptr of ptrs) {
       try {
-        const addrs = await this.resolver[resolve_method](ptr)
+        const addrs = await this._withTimeout(
+          this.resolver[resolve_method](ptr),
+          `${resolve_method} ${ptr}`,
+        )
         for (const addr of addrs) {
           if (addr === this.ip) {
             this.log_debug(`mech_ptr: ${this.ip} => ${ptr} => ${addr}: MATCH!`)
@@ -616,7 +685,11 @@ class SPF {
     // Catch bogus PTR matches e.g. ptr:*.bahnhof.se (should be ptr:bahnhof.se)
     // These will cause a regexp error, so we can catch them.
     try {
-      const re = new RegExp(`${domain.replace('.', '\\.')}$`, 'i')
+      // Escape every literal dot, and anchor with `^` or `.` so that
+      // `example.com` only matches itself or a real subdomain (not
+      // `evilexample.com`). See RFC 7208 §5.5.
+      const escaped = domain.replace(/\./g, '\\.')
+      const re = new RegExp(`(?:^|\\.)${escaped}$`, 'i')
       for (const name of names) {
         if (re.test(name)) {
           this.log_debug(`mech_ptr: ${name} => ${domain}: MATCH!`)

--- a/lib/spf.js
+++ b/lib/spf.js
@@ -681,28 +681,21 @@ class SPF {
       }
     }
 
-    // Finished
-    // Catch bogus PTR matches e.g. ptr:*.bahnhof.se (should be ptr:bahnhof.se)
-    // These will cause a regexp error, so we can catch them.
-    try {
-      // Escape every literal dot, and anchor with `^` or `.` so that
-      // `example.com` only matches itself or a real subdomain (not
-      // `evilexample.com`). See RFC 7208 §5.5.
-      const escaped = domain.replace(/\./g, '\\.')
-      const re = new RegExp(`(?:^|\\.)${escaped}$`, 'i')
-      for (const name of names) {
-        if (re.test(name)) {
-          this.log_debug(`mech_ptr: ${name} => ${domain}: MATCH!`)
-          return this.return_const(qualifier)
-        } else {
-          this.log_debug(`mech_ptr: ${name} => ${domain}: NO MATCH`)
-        }
+    // RFC 7208 §5.5: a PTR mechanism matches when the validated name
+    // equals the target domain or is a subdomain of it. Suffix match
+    // with a leading-dot boundary; no regex, so no metacharacter
+    // escaping concerns.
+    const target = domain.toLowerCase()
+    const dotTarget = `.${target}`
+    for (const name of names) {
+      const lname = name.toLowerCase()
+      if (lname === target || lname.endsWith(dotTarget)) {
+        this.log_debug(`mech_ptr: ${name} => ${domain}: MATCH!`)
+        return this.return_const(qualifier)
       }
-      return this.SPF_NONE
-    } catch (e) {
-      this.log_debug('mech_ptr', { domain: this.domain, err: e.message })
-      return this.SPF_PERMERROR
+      this.log_debug(`mech_ptr: ${name} => ${domain}: NO MATCH`)
     }
+    return this.SPF_NONE
   }
 
   async mech_ip(qualifier, args) {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "spf": "./bin/spf"
   },
   "dependencies": {
-    "haraka-dsn": "^1.1.0",
+    "haraka-dsn": "^1.2.0",
     "haraka-net-utils": "^1.8.2",
     "ipaddr.js": "^2.4.0",
     "nopt": "^10.0.0"

--- a/test/index.js
+++ b/test/index.js
@@ -39,6 +39,32 @@ describe('load_spf_ini', () => {
   })
 })
 
+describe('_configure_spf', () => {
+  it('copies a validated fcrdns name into spf.p_name', () => {
+    const conn = {
+      results: {
+        get: (name) =>
+          name === 'fcrdns' ? { fcrdns: ['mta.sender.example'] } : null,
+      },
+    }
+    const out = plugin._configure_spf(new SPF(), conn)
+    assert.equal(out.p_name, 'mta.sender.example')
+  })
+
+  it('leaves p_name undefined when fcrdns has no validated names', () => {
+    const conn = {
+      results: { get: () => ({ fcrdns: [] }) },
+    }
+    const out = plugin._configure_spf(new SPF(), conn)
+    assert.equal(out.p_name, undefined)
+  })
+
+  it('is safe when connection has no results store', () => {
+    const out = plugin._configure_spf(new SPF(), undefined)
+    assert.equal(out.p_name, undefined)
+  })
+})
+
 describe('return_results', () => {
   it('result, none, reject=false', (t, done) => {
     plugin.cfg.deny.mfrom_none = false

--- a/test/spf.js
+++ b/test/spf.js
@@ -1,6 +1,7 @@
 const assert = require('node:assert')
 const { describe, it, before, after, beforeEach } = require('node:test')
 
+const ipaddr = require('ipaddr.js')
 const fixtures = require('haraka-test-fixtures')
 
 const SPF = require('../lib/spf').SPF
@@ -26,6 +27,27 @@ const ZONES = {
   },
   'mail1.mx.example': { a: ['1.1.1.1'] },
   'mail2.mx.example': { a: ['2.2.2.2'] },
+  // 11 `a:` mechanisms — over the RFC 7208 §4.6.4 limit of 10.
+  'limit11.example': {
+    txt: 'v=spf1 a:n1.example a:n2.example a:n3.example a:n4.example a:n5.example a:n6.example a:n7.example a:n8.example a:n9.example a:n10.example a:match.example -all',
+  },
+  'n1.example': { a: ['9.9.9.9'] },
+  'n2.example': { a: ['9.9.9.9'] },
+  'n3.example': { a: ['9.9.9.9'] },
+  'n4.example': { a: ['9.9.9.9'] },
+  'n5.example': { a: ['9.9.9.9'] },
+  'n6.example': { a: ['9.9.9.9'] },
+  'n7.example': { a: ['9.9.9.9'] },
+  'n8.example': { a: ['9.9.9.9'] },
+  'n9.example': { a: ['9.9.9.9'] },
+  'n10.example': { a: ['9.9.9.9'] },
+  'match.example': { a: ['1.2.3.4'] },
+  // Three `a:` mechanisms pointing at undefined names (NXDOMAIN). After
+  // the third void lookup, RFC 7208 §4.6.4 requires PermError.
+  'voidparent.example': {
+    txt: 'v=spf1 a:vd1.example a:vd2.example a:vd3.example -all',
+  },
+  // vd1/vd2/vd3.example intentionally not defined -> NXDOMAIN
 }
 
 let dns, restore, spfInst
@@ -129,5 +151,136 @@ describe('SPF', () => {
     const rc = await spfInst.check_host('5.6.7.8', 'inc.example')
     assert.equal(rc, spfInst.SPF_PASS, 'included record matched')
     assert.ok(spfInst.spf_record.includes('include:_spf.inc.example'))
+  })
+
+  it('mech_ptr escapes every dot in a multi-label domain', async () => {
+    // Bug C1: `domain.replace('.', '\\.')` only escapes the first dot.
+    // For domain `example.co.uk` the buggy regex becomes
+    // /example\.co.uk$/i, where `.` between `co` and `uk` matches any
+    // character. A reverse-lookup name like `evil.example.coXuk` (after
+    // forward-confirmation) would then yield a false-positive MATCH.
+    spfInst.count = 0
+    spfInst.ip = '1.2.3.4'
+    spfInst.ipaddr = ipaddr.parse('1.2.3.4')
+    spfInst.ip_ver = 'ipv4'
+    spfInst.domain = 'example.co.uk'
+    spfInst.resolver = {
+      reverse: async () => ['evil.example.coXuk'],
+      resolve4: async () => ['1.2.3.4'],
+    }
+    const rc = await spfInst.mech_ptr('+', null)
+    assert.equal(rc, spfInst.SPF_NONE)
+  })
+
+  it('mech_ptr only matches the domain itself or a subdomain', async () => {
+    // A PTR ending in `evilexample.com` must not match domain `example.com`.
+    spfInst.count = 0
+    spfInst.ip = '1.2.3.4'
+    spfInst.ipaddr = ipaddr.parse('1.2.3.4')
+    spfInst.ip_ver = 'ipv4'
+    spfInst.domain = 'example.com'
+    spfInst.resolver = {
+      reverse: async () => ['evilexample.com'],
+      resolve4: async () => ['1.2.3.4'],
+    }
+    const rc = await spfInst.mech_ptr('+', null)
+    assert.equal(rc, spfInst.SPF_NONE)
+  })
+
+  it('check_host returns TempError when a DNS lookup hangs past the timeout', async () => {
+    // Bug S2: the plugin's outer hook timer bounds the whole hook, but
+    // the SPF engine itself doesn't bound individual DNS operations.
+    // A hanging resolver should be surfaced as TempError, not block
+    // until the outer timer fires.
+    const hung = new SPF()
+    hung.dns_timeout_ms = 50
+    hung.resolver = {
+      resolveTxt: () => new Promise(() => {}),
+    }
+    const rc = await hung.check_host(
+      '1.2.3.4',
+      'hang.example',
+      'a@hang.example',
+    )
+    assert.equal(rc, hung.SPF_TEMPERROR)
+  })
+
+  it('check_host returns PermError after 3 void lookups', async () => {
+    // RFC 7208 §4.6.4: void lookups (NODATA / NXDOMAIN from a/mx/ptr/
+    // exists/include/redirect) are limited to two. The third must yield
+    // PermError. Without the fix, three NXDOMAIN `a:` mechanisms each
+    // return SPF_NONE and evaluation falls through to `-all`, returning
+    // Fail instead.
+    spfInst.count = 0
+    const rc = await spfInst.check_host(
+      '1.2.3.4',
+      'voidparent.example',
+      'haraka@voidparent.example',
+    )
+    assert.equal(rc, spfInst.SPF_PERMERROR)
+  })
+
+  it('check_host returns PermError once the 10-lookup budget is exceeded', async () => {
+    // Bug S1: the pre-mechanism lookup-limit check at the top of the loop
+    // honors a mechanism result before re-checking the counter. An 11th
+    // DNS-producing mechanism that yields Pass/Fail is returned even
+    // though RFC 7208 §4.6.4 requires PermError once the budget is
+    // exceeded. Eleven `a:` mechanisms where the 11th matches should
+    // therefore return PermError, not Pass.
+    spfInst.count = 0
+    const rc = await spfInst.check_host(
+      '1.2.3.4',
+      'limit11.example',
+      'haraka@limit11.example',
+    )
+    assert.equal(rc, spfInst.SPF_PERMERROR)
+  })
+
+  it('mech_include surfaces internal errors as TempError', async () => {
+    // Bug C3: the catch in mech_include swallows internal errors and
+    // returns undefined, which the caller then treats as falsy and
+    // continues evaluating. A non-iterable from resolveTxt makes
+    // recurse.check_host throw (its `for ... of` runs outside the
+    // try/catch). The expected behaviour is a defined SPF status.
+    spfInst.count = 0
+    spfInst.ip = '1.2.3.4'
+    spfInst.ip_ver = 'ipv4'
+    spfInst.mail_from = 'test@inc.example'
+    spfInst.resolver = {
+      resolveTxt: async () => null,
+    }
+    const rc = await spfInst.mech_include('+', ':_spf.inc.example')
+    assert.equal(rc, spfInst.SPF_TEMPERROR)
+  })
+
+  it('expand_macros %{p} uses p_name when set', () => {
+    spfInst.helo = 'mail.example.com'
+    spfInst.domain = 'example.com'
+    spfInst.ip = '1.2.3.4'
+    spfInst.mail_from = 'a@example.com'
+    spfInst.p_name = 'mta.sender.example'
+    assert.equal(spfInst.expand_macros('%{p}'), 'mta.sender.example')
+  })
+
+  it('expand_macros %{p} falls back to "unknown" when p_name is not set', () => {
+    spfInst.helo = 'mail.example.com'
+    spfInst.domain = 'example.com'
+    spfInst.ip = '1.2.3.4'
+    spfInst.mail_from = 'a@example.com'
+    assert.equal(spfInst.expand_macros('%{p}'), 'unknown')
+  })
+
+  it('mech_ptr still matches a real subdomain', async () => {
+    spfInst.count = 0
+    spfInst.ip = '1.2.3.4'
+    spfInst.ipaddr = ipaddr.parse('1.2.3.4')
+    spfInst.ip_ver = 'ipv4'
+    spfInst.domain = 'example.co.uk'
+    spfInst.resolver = {
+      reverse: async () => ['mail.example.co.uk'],
+      resolve4: async () => ['1.2.3.4'],
+    }
+    const rc = await spfInst.mech_ptr('+', null)
+    assert.equal(rc, spfInst.SPF_PASS)
   })
 })


### PR DESCRIPTION
- fix: global dot-escape + (?:^|\.) boundary anchor
- fix: mech_include catch now returns SPF_TEMPERROR and logs error
- fix: pre-check changed to >= LIMIT (blocks the 11th)
- fix: README links stale RFC 4408 → RFC 7208
- fix: enforce RFC 7208 §4.6.4 void-lookup limit (PermError after 2)
- feat: per-DNS-query timeout (configurable via `dns_timeout`)
- feat: %{p} macro expands via fcrdns plugin's validated PTR (RFC 7208 §7.3)
- doc: list `exp=` as unsupported in README
